### PR TITLE
Adds GA4 / SGTM internal parameters to Bundle:

### DIFF
--- a/app-measurement.desc
+++ b/app-measurement.desc
@@ -1,6 +1,6 @@
 
-ù
-app-measurement.protoapp_measurement"Œ
+Æ
+app-measurement.protoapp_measurement"Ù
 Bundle)
 protocol_version (RprotocolVersion3
 event (2.app_measurement.Bundle.EventReventI
@@ -21,16 +21,23 @@ $previous_bundle_end_timestamp_millis (R previousBundleEndTimestampMillis
 appVersion
 gmp_version (R
 gmpVersion2
-uploading_gmp_version (RuploadingGmpVersion&
-app_instance_id (	RappInstanceId6
+uploading_gmp_version (RuploadingGmpVersion0
+resettable_device_id (	RresettableDeviceId
+npa (	Rnpa&
+app_instance_id (	RappInstanceId"
+dev_cert_hash (	RdevCertHash6
 bundle_sequential_index (RbundleSequentialIndex
 
 gmp_app_id (	RgmpAppIdR
-&previous_bundle_start_timestamp_millis (R"previousBundleStartTimestampMillis0
-resettable_device_id (	RresettableDeviceId0
+&previous_bundle_start_timestamp_millis (R"previousBundleStartTimestampMillis7
+resettable_device_id_alt (	RresettableDeviceIdAlt0
 firebase_instance_id (	RfirebaseInstanceId*
-app_version_major (RappVersionMajor%
-config_version# (RconfigVersion¬
+app_version_major (RappVersionMajor*
+target_os_version# (	RtargetOsVersionK
+"system_properties_dynamite_version. (	RsystemPropertiesDynamiteVersion
+gcs4 (	Rgcs/
+consent_diagnosticsG (	RconsentDiagnosticsG
+ system_properties_delivery_indexM (RsystemPropertiesDeliveryIndex¬
 EventB
 param (2,.app_measurement.Bundle.Event.EventParameterRparam
 name (	Rname)

--- a/app-measurement.proto
+++ b/app-measurement.proto
@@ -46,9 +46,15 @@ message Bundle {
     int32 gmp_version = 17;
     int32 uploading_gmp_version = 18;
 
-    // 20 unknown, example values: "1"
+    // x-ga-resettable_device_id
+    string resettable_device_id = 19;
+
+    // x-ga-npa (non-personalized ads) documented type: string (values often "1" for enabled). Kept as string per SGTM internal params.
+    string npa_non_personalized_ads = 20;
 
     string app_instance_id = 21;
+    // x-ga-dev_cert_hash
+    string dev_cert_hash = 22;
 
     int32 bundle_sequential_index = 23;
 
@@ -56,17 +62,28 @@ message Bundle {
 
     int64 previous_bundle_start_timestamp_millis = 26;
 
-    string resettable_device_id = 27; // Android ID or IDFV
+    string resettable_device_id_alt = 27; // Android ID or IDFV
 
     string firebase_instance_id = 30;
 
     int32 app_version_major = 31;
 
-    int64 config_version = 35;
+    // x-ga-target_os_version
+    // Previous config_version (kept in comment for historical reference)
+    string target_os_version = 35;
 
-    // 52 unknown, example values: "G1--"
+    // x-ga-system_properties.dynamite_version
+    string system_properties_dynamite_version = 46;
+
+    // x-ga-gcs (google consent state)
+    string gcs_google_consent_state = 52;
     // 53 unknown, example values: "2"
     // 64 unknown, example values: "google_signals"
+    // x-ga-consent_diagnostics
+    string consent_diagnostics = 71;
+
+    // x-ga-system_properties.delivery_index
+    int32 system_properties_delivery_index = 77;
     
 }
 


### PR DESCRIPTION
19 resettable_device_id (moved here from 27)
20 npa (string, non-personalized ads flag)
22 dev_cert_hash
27 resettable_device_id_alt (legacy/original position) 35 target_os_version (was int64 config_version) BREAKING: name + type change (int64 -> string) 46 system_properties_dynamite_version (string)
52 gcs (consent state)
71 consent_diagnostics (raw string placeholder)
77 system_properties_delivery_index

Fixes #1 